### PR TITLE
Change the example module name to ntpoffset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,10 +30,10 @@ To configure the plugin:
     </LoadPlugin>
 
     <Plugin python>
-      Import "collectd_ntp"
+      Import "ntpoffset"
 
-      <Module "collectd_ntp">
+      <Module "ntpoffset">
         # NTP pool address
-        pool "127.0.0.1"
+        pool "pool.ntp.org"
       </Module>
     </Plugin>

--- a/ntpoffset.py
+++ b/ntpoffset.py
@@ -25,7 +25,7 @@ class NtpOffsetConfigException(Exception):
 
 
 class NtpOffset(object):
-    PLUGIN_NAME = 'collectd_ntp'
+    PLUGIN_NAME = 'ntpoffset'
 
     def __init__(self, config=None):
         self.pool = None

--- a/tests/test_ntpoffset.py
+++ b/tests/test_ntpoffset.py
@@ -79,7 +79,7 @@ class NtpOffsetPluginTest(unittest.TestCase):
         return self.ntpoffset.NtpOffset(*args)
 
     def test_plugin_identifies_itself(self):
-        self.assertEqual('collectd_ntp', self.plugin().PLUGIN_NAME)
+        self.assertEqual('ntpoffset', self.plugin().PLUGIN_NAME)
 
     def test_minimal_config_requires_pool_name(self):
         try:


### PR DESCRIPTION
And use an actual ntp pool as an example
